### PR TITLE
feat: implement change list sync with JetBrains/PhpStorm and bug fixes

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,7 +9,6 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 !out/**/*.js
-node_modules/**
 CONCEPT.md
 BLUEPRINT.md
 OVERVIEW.md

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Git Change Lists transforms how you organize Git changes by introducing **change
 - ✓ **Commit Guard** - Warns when staging files from multiple lists
 - ✓ **Git Integration** - Works seamlessly with VS Code's built-in Git
 - ✓ **Status Bar Integration** - See your active list at a glance
+- ✓ **JetBrains / PhpStorm Sync** - Bi-directional synchronization of change lists with `.idea/workspace.xml`
 - ✓ **Multi-Editor Support** - Works on VS Code, Cursor, Kiro, Windsurf, Trae, VSCodium, and Antigravity
 
 ---
@@ -75,6 +76,9 @@ If you're a WebStorm, IntelliJ IDEA, or PHPStorm user who's had to switch to VS 
 - Active list concept with auto-assignment
 - Default list that captures unassigned changes
 - Staging-based workflow that integrates with VS Code's native Git
+
+> [!NOTE]
+> **JetBrains Sync Limitation**: Since JetBrains IDEs keep their change list state in memory and only flush to `.idea/workspace.xml` when the IDE loses focus, during an auto-save, or when explicitly saved, the synchronization from PhpStorm/IntelliJ to VS Code may not always feel real-time. Changes made in VS Code, however, are immediately exported back to PhpStorm.
 
 ---
 
@@ -315,6 +319,8 @@ Git Change Lists can be configured via **File → Preferences → Settings** or 
 | `gitChangeLists.commitGuard.enabled` | `boolean` | `true` | Warn when committing files from multiple lists |
 | `gitChangeLists.commitGuard.interceptCommit` | `boolean` | `false` | Intercept native commit command (requires restart) |
 | `gitChangeLists.autoAssignStagedFiles` | `boolean` | `true` | Auto-assign externally staged files to active list |
+| `gitChangeLists.ideaSync.enabled` | `boolean` | `true` | Enable bi-directional synchronization of change lists with PhpStorm (`.idea/workspace.xml`) |
+| `gitChangeLists.ideaSync.interval` | `integer` | `1000` | Debounce interval (in ms) for writing change lists back to PhpStorm |
 | `gitChangeLists.debug.enableLogging` | `boolean` | `false` | Enable verbose debug logging to output channel |
 
 ### Example Configuration
@@ -326,6 +332,8 @@ Git Change Lists can be configured via **File → Preferences → Settings** or 
   "gitChangeLists.autoActivateNew": true,
   "gitChangeLists.commitGuard.enabled": true,
   "gitChangeLists.autoAssignStagedFiles": true,
+  "gitChangeLists.ideaSync.enabled": true,
+  "gitChangeLists.ideaSync.interval": 1000,
   "gitChangeLists.debug.enableLogging": false
 }
 ```

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -60,6 +60,8 @@ Quick reference table of all available settings:
 | `smartCommit.commitGuard.enabled` | `boolean` | `true` | Global | Warn when staging mixed change lists |
 | `smartCommit.commitGuard.interceptCommit` | `boolean` | `false` | Global | Intercept native commit command |
 | `smartCommit.autoAssignStagedFiles` | `boolean` | `true` | Global | Auto-assign externally staged files |
+| `gitChangeLists.ideaSync.enabled` | `boolean` | `true` | Workspace | Enable PhpStorm bi-directional synchronization |
+| `gitChangeLists.ideaSync.interval` | `integer` | `1000` | Global | Debounce interval (in ms) for PhpStorm sync |
 | `smartCommit.debug.enableLogging` | `boolean` | `true` | Global | Enable verbose debug logging |
 
 ---
@@ -411,6 +413,43 @@ Enables verbose DEBUG-level logging to the "Smart Commit" output channel.
 3. Filter by search if needed
 
 See [DEBUGGING.md](DEBUGGING.md) for more details.
+
+---
+
+### JetBrains / PhpStorm Integration
+
+#### `gitChangeLists.ideaSync.enabled`
+
+**Type:** `boolean`
+**Default:** `true`
+**Scope:** Workspace
+**Restart Required:** No
+
+**Description:**
+Enables bi-directional synchronization of change lists and file mappings with PhpStorm and other JetBrains IDEs via the `.idea/workspace.xml` file.
+
+**When `true`:**
+- Automatically imports change lists and file mappings from PhpStorm on startup and watches the file for changes
+- Periodically checks for external updates using a polling fallback (every 2.5 seconds) to work reliably on WSL/UNC shares
+- Exports local change list state back to `.idea/workspace.xml` when files are moved or lists are updated
+
+**When `false`:**
+- Disables all PhpStorm synchronization features
+
+> [!NOTE]
+> **JetBrains Sync Limitation**: Since JetBrains IDEs keep their change list state in memory and only flush to `.idea/workspace.xml` when the IDE loses focus, during an auto-save, or when explicitly saved, the synchronization from PhpStorm/IntelliJ to VS Code may not always feel real-time. Changes made in VS Code, however, are immediately exported back to PhpStorm.
+
+---
+
+#### `gitChangeLists.ideaSync.interval`
+
+**Type:** `integer`
+**Default:** `1000`
+**Scope:** Global
+**Restart Required:** No
+
+**Description:**
+Debounce interval (in milliseconds) used when exporting local change list changes back to the `.idea/workspace.xml` file. Prevents excessive disk writes during rapid operations.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "git-change-lists",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "simple-git": "^3.x",
         "uuid": "^9.x"

--- a/package.json
+++ b/package.json
@@ -179,6 +179,13 @@
           "group": "1_move@1"
         }
       ],
+      "scm/resourceState/context": [
+        {
+          "command": "gitChangeLists.moveToList",
+          "when": "scmProvider == git",
+          "group": "inline@1"
+        }
+      ],
       "commandPalette": [
         {
           "command": "gitChangeLists.deleteList",
@@ -267,6 +274,16 @@
           "type": "boolean",
           "default": false,
           "description": "Enable debug logging to the output channel (verbose)"
+        },
+        "gitChangeLists.ideaSync.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable bi-directional synchronization of change lists with PhpStorm (.idea/workspace.xml)"
+        },
+        "gitChangeLists.ideaSync.interval": {
+          "type": "integer",
+          "default": 1000,
+          "description": "Debounce interval (in ms) for writing change lists to .idea/workspace.xml"
         }
       }
     }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -222,29 +222,30 @@ export function registerCommands(
 
   // Move to Change List
   disposables.push(
-    vscode.commands.registerCommand(COMMANDS.MOVE_TO_LIST, async (node?: FileNode, nodes?: FileNode[]) => {
+    vscode.commands.registerCommand(COMMANDS.MOVE_TO_LIST, async (node?: unknown, nodes?: unknown[]) => {
       // Get selected files
       let filesToMove: string[] = [];
 
       if (nodes && nodes.length > 0) {
         // Multi-selection
         filesToMove = nodes
-          .map((n: any) => {
-            if (n && n.type === 'file' && n.change && n.change.resourceUri) {
-              return n.change.resourceUri.fsPath;
+          .map((n) => {
+            const item = n as { type?: string; change?: { resourceUri?: vscode.Uri }; resourceUri?: vscode.Uri };
+            if (item && item.type === 'file' && item.change?.resourceUri) {
+              return item.change.resourceUri.fsPath;
             }
-            if (n && n.resourceUri) {
-              return n.resourceUri.fsPath;
+            if (item && item.resourceUri) {
+              return item.resourceUri.fsPath;
             }
             return '';
           })
           .filter(Boolean);
       } else if (node) {
-        const anyNode = node as any;
-        if (anyNode.type === 'file' && anyNode.change && anyNode.change.resourceUri) {
-          filesToMove = [anyNode.change.resourceUri.fsPath];
-        } else if (anyNode.resourceUri) {
-          filesToMove = [anyNode.resourceUri.fsPath];
+        const item = node as { type?: string; change?: { resourceUri?: vscode.Uri }; resourceUri?: vscode.Uri };
+        if (item.type === 'file' && item.change?.resourceUri) {
+          filesToMove = [item.change.resourceUri.fsPath];
+        } else if (item.resourceUri) {
+          filesToMove = [item.resourceUri.fsPath];
         }
       }
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -229,10 +229,23 @@ export function registerCommands(
       if (nodes && nodes.length > 0) {
         // Multi-selection
         filesToMove = nodes
-          .filter((n): n is FileNode => n.type === 'file')
-          .map((n) => n.change.resourceUri.fsPath);
-      } else if (node && node.type === 'file') {
-        filesToMove = [node.change.resourceUri.fsPath];
+          .map((n: any) => {
+            if (n && n.type === 'file' && n.change && n.change.resourceUri) {
+              return n.change.resourceUri.fsPath;
+            }
+            if (n && n.resourceUri) {
+              return n.resourceUri.fsPath;
+            }
+            return '';
+          })
+          .filter(Boolean);
+      } else if (node) {
+        const anyNode = node as any;
+        if (anyNode.type === 'file' && anyNode.change && anyNode.change.resourceUri) {
+          filesToMove = [anyNode.change.resourceUri.fsPath];
+        } else if (anyNode.resourceUri) {
+          filesToMove = [anyNode.resourceUri.fsPath];
+        }
       }
 
       if (filesToMove.length === 0) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { ChangeListDragDropController } from './providers/dragDropController';
 import { registerCommands } from './commands';
 import { VIEW_ID } from './utils/constants';
 import { logger } from './utils/logger';
+import { IdeaSyncService } from './services/ideaSyncService';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   // Register logger output channel
@@ -88,11 +89,58 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     commitGuardService.initialize();
     logger.info('Commit guard service initialized');
 
+    // Initialize PhpStorm sync service
+    logger.debug('Initializing PhpStorm sync service...');
+    const ideaSyncService = new IdeaSyncService(
+      changeListManager,
+      gitService,
+      configService
+    );
+    await ideaSyncService.initialize();
+
+    // Create and integrate Status Bar Item
+    logger.debug('Creating status bar item...');
+    let statusBarItem: vscode.StatusBarItem | undefined;
+
+    const updateStatusBar = () => {
+      if (!configService.getShowStatusBar() || !gitService.hasRepository()) {
+        if (statusBarItem) {
+          statusBarItem.hide();
+        }
+        return;
+      }
+
+      const activeList = changeListManager.getActiveList();
+      if (!activeList) {
+        if (statusBarItem) {
+          statusBarItem.hide();
+        }
+        return;
+      }
+
+      if (!statusBarItem) {
+        statusBarItem = vscode.window.createStatusBarItem(
+          vscode.StatusBarAlignment.Left,
+          100
+        );
+        statusBarItem.command = 'gitChangeLists.setActiveList';
+        context.subscriptions.push(statusBarItem);
+      }
+
+      statusBarItem.text = `$(git-branch) Change List: ${activeList.name}`;
+      statusBarItem.tooltip = `Active Change List: ${activeList.name}\nClick to switch active change list`;
+      statusBarItem.show();
+    };
+
+    // Update status bar initially
+    updateStatusBar();
+
     // Subscribe to Git state changes
     logger.debug('Setting up event listeners...');
     gitService.onDidChangeState(() => {
       logger.event('Git', 'State changed');
       treeDataProvider.refresh();
+      updateStatusBar();
     });
 
     // Subscribe to externally staged files (auto-assignment)
@@ -148,6 +196,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     changeListManager.onDidChange((event) => {
       logger.event('ChangeList', 'State changed', event);
       treeDataProvider.refresh();
+      updateStatusBar();
     });
 
     // Subscribe to configuration changes
@@ -161,6 +210,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
 
       treeDataProvider.refresh();
+      updateStatusBar();
     });
 
     // Add services to subscriptions for cleanup
@@ -168,7 +218,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       changeListManager,
       gitService,
       commitGuardService,
-      treeDataProvider
+      treeDataProvider,
+      ideaSyncService
     );
 
     logger.info('Git Change Lists extension activated successfully!');

--- a/src/services/changeListManager.ts
+++ b/src/services/changeListManager.ts
@@ -13,7 +13,7 @@ import {
   DEFAULT_LIST_NAME,
   UNVERSIONED_LIST_ID,
 } from '../utils/constants';
-import { generateId, now, getRelativePath } from '../utils/helpers';
+import { generateId, now, getRelativePath, normalizePathKey } from '../utils/helpers';
 import { logger } from '../utils/logger';
 
 /**
@@ -53,9 +53,6 @@ export class ChangeListManager implements vscode.Disposable {
 
     // Ensure default list exists
     this.ensureDefaultList();
-
-    // Clean up file mappings for files that no longer exist in Git
-    await this.cleanupStaleFileMappings();
 
     logger.info('ChangeListManager: Initialized', {
       listCount: this.state.lists.length,
@@ -140,7 +137,7 @@ export class ChangeListManager implements vscode.Disposable {
    */
   private async cleanupStaleFileMappings(): Promise<void> {
     const modifiedFiles = await this.gitService.getModifiedFiles();
-    const modifiedPaths = new Set(modifiedFiles.map((f) => f.uri.fsPath));
+    const modifiedPaths = new Set(modifiedFiles.map((f) => normalizePathKey(f.uri.fsPath)));
 
     const staleFiles: string[] = [];
     for (const filePath of Object.keys(this.state.fileMapping)) {
@@ -356,7 +353,8 @@ export class ChangeListManager implements vscode.Disposable {
    * Get the change list ID for a file
    */
   getListIdForFile(filePath: string): string {
-    return this.state.fileMapping[filePath] ?? this.getDefaultList().id;
+    const key = normalizePathKey(filePath);
+    return this.state.fileMapping[key] ?? this.getDefaultList().id;
   }
 
   /**
@@ -376,7 +374,8 @@ export class ChangeListManager implements vscode.Disposable {
       throw new Error('Change list not found');
     }
 
-    this.state.fileMapping[filePath] = listId;
+    const key = normalizePathKey(filePath);
+    this.state.fileMapping[key] = listId;
     await this.persistState();
     this._onDidChange.fire({ type: 'filesMoved', changeListId: listId, affectedFiles: [filePath] });
   }
@@ -404,7 +403,8 @@ export class ChangeListManager implements vscode.Disposable {
 
         // Remove from file mapping so they fall back to being untracked (which getFilesForList handles)
         for (const filePath of filePaths) {
-          delete this.state.fileMapping[filePath];
+          const key = normalizePathKey(filePath);
+          delete this.state.fileMapping[key];
         }
       } catch (error) {
         logger.error('ChangeListManager: Failed to unstage files', error);
@@ -416,7 +416,8 @@ export class ChangeListManager implements vscode.Disposable {
 
       for (const filePath of filePaths) {
         // Update mapping
-        this.state.fileMapping[filePath] = targetListId;
+        const key = normalizePathKey(filePath);
+        this.state.fileMapping[key] = targetListId;
 
         // Check if file is currently untracked (via git status)
         // We'll need to check the actual status from GitService or assume based on current list
@@ -528,8 +529,59 @@ export class ChangeListManager implements vscode.Disposable {
    */
   async removeFileMappings(filePaths: string[]): Promise<void> {
     for (const filePath of filePaths) {
-      delete this.state.fileMapping[filePath];
+      const key = normalizePathKey(filePath);
+      delete this.state.fileMapping[key];
     }
+    await this.persistState();
+    this._onDidChange.fire({ type: 'refresh' });
+  }
+
+  /**
+   * Import change lists and file mappings from PhpStorm/Idea configuration
+   */
+  async importStateFromIdea(
+    lists: { id: string; name: string; isDefault: boolean }[],
+    fileMapping: Record<string, string>
+  ): Promise<void> {
+    logger.debug('ChangeListManager: Importing state from PhpStorm', {
+      listCount: lists.length,
+      mappingCount: Object.keys(fileMapping).length,
+    });
+
+    const timestamp = now();
+    const updatedLists = lists.map((l) => {
+      const existing = this.state.lists.find((el) => el.id === l.id);
+      return {
+        id: l.id,
+        name: l.name,
+        isDefault: l.isDefault,
+        isActive: existing ? existing.isActive : l.isDefault,
+        createdAt: existing ? existing.createdAt : timestamp,
+        updatedAt: timestamp,
+        description: existing ? existing.description : undefined,
+        color: existing ? existing.color : undefined,
+      };
+    });
+
+    // Ensure at least one list is active
+    if (!updatedLists.some((l) => l.isActive)) {
+      const defaultList = updatedLists.find((l) => l.isDefault);
+      if (defaultList) {
+        defaultList.isActive = true;
+      } else if (updatedLists.length > 0) {
+        updatedLists[0].isActive = true;
+      }
+    }
+
+    this.state.lists = updatedLists;
+    
+    // Normalize mapping keys
+    const normalizedMapping: Record<string, string> = {};
+    for (const [filePath, listId] of Object.entries(fileMapping)) {
+      normalizedMapping[normalizePathKey(filePath)] = listId;
+    }
+    this.state.fileMapping = normalizedMapping;
+
     await this.persistState();
     this._onDidChange.fire({ type: 'refresh' });
   }

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -70,6 +70,20 @@ export class ConfigService {
   }
 
   /**
+   * Get whether PhpStorm sync is enabled
+   */
+  getIdeaSyncEnabled(): boolean {
+    return this.getConfig().get<boolean>(CONFIG.IDEA_SYNC_ENABLED, true);
+  }
+
+  /**
+   * Get PhpStorm sync interval in milliseconds
+   */
+  getIdeaSyncInterval(): number {
+    return this.getConfig().get<number>(CONFIG.IDEA_SYNC_INTERVAL, 1000);
+  }
+
+  /**
    * Listen for configuration changes
    */
   onDidChangeConfiguration(

--- a/src/services/gitService.ts
+++ b/src/services/gitService.ts
@@ -36,6 +36,7 @@ export class GitService implements vscode.Disposable {
   // Track previously staged files to detect new staging
   private previouslyStagedFiles = new Set<string>();
   private lastKnownHead: string | undefined;
+  private programmaticOperations = new Set<string>();
 
   constructor() {
     this.debouncedEmitChange = debounce(() => {
@@ -174,6 +175,10 @@ export class GitService implements vscode.Disposable {
     const newlyStagedFiles: StagedFileChange[] = [];
     for (const filePath of currentlyStagedFiles) {
       if (!this.previouslyStagedFiles.has(filePath)) {
+        if (this.programmaticOperations.has(filePath)) {
+          this.programmaticOperations.delete(filePath);
+          continue;
+        }
         const change = state.indexChanges.find((c) => c.uri.fsPath === filePath);
         if (change) {
           newlyStagedFiles.push({
@@ -192,12 +197,10 @@ export class GitService implements vscode.Disposable {
       this._onDidStageFiles.fire(newlyStagedFiles);
     }
 
-    this.previouslyStagedFiles = currentlyStagedFiles;
-
-    // Check for commits (HEAD changed)
+    // Check for commits (HEAD changed) BEFORE updating previouslyStagedFiles
     const currentHead = state.HEAD?.commit;
     if (currentHead && currentHead !== this.lastKnownHead && this.lastKnownHead) {
-      // A commit happened - emit the files that were staged before
+      // A commit happened - emit the files that were staged before this change
       const committedFiles = Array.from(this.previouslyStagedFiles);
       logger.debug('GitService: Commit detected', {
         newHead: currentHead.substring(0, 8),
@@ -206,6 +209,8 @@ export class GitService implements vscode.Disposable {
       });
       this._onDidCommit.fire(committedFiles);
     }
+
+    this.previouslyStagedFiles = currentlyStagedFiles;
     this.lastKnownHead = currentHead;
   }
 
@@ -286,19 +291,30 @@ export class GitService implements vscode.Disposable {
     const repoRoot = this.repository.rootUri.fsPath;
     const filePaths = uris.map(u => u.fsPath);
 
+    // Track these as programmatic operations to prevent auto-assignment bounce-back
+    for (const filePath of filePaths) {
+      this.programmaticOperations.add(filePath);
+    }
+
+    // Convert to relative paths with forward slashes for Git consistency
+    const relativePaths = filePaths.map(p => {
+      const rel = path.relative(repoRoot, p);
+      return rel.replace(/\\/g, '/');
+    });
+
     logger.debug('GitService: Staging files via git add', {
-      count: filePaths.length,
+      count: relativePaths.length,
       repoRoot,
-      files: filePaths,
+      files: relativePaths,
     });
 
     // Use git add directly to bypass VS Code Git extension API issues
-    await this.runGitCommand(repoRoot, ['add', '--', ...filePaths]);
+    await this.runGitCommand(repoRoot, ['add', '--', ...relativePaths]);
 
     // Refresh repository state to pick up the changes
     await this.repository.status();
 
-    logger.info('GitService: Files staged successfully', { count: filePaths.length });
+    logger.info('GitService: Files staged successfully', { count: relativePaths.length });
   }
 
   /**
@@ -308,7 +324,8 @@ export class GitService implements vscode.Disposable {
     return new Promise((resolve, reject) => {
       logger.debug('GitService: Running git command', { args, cwd });
 
-      cp.execFile('git', args, { cwd, encoding: 'utf8' }, (error, stdout, stderr) => {
+      const gitPath = vscode.workspace.getConfiguration('git').get<string>('path') || 'git';
+      cp.execFile(gitPath, args, { cwd, encoding: 'utf8' }, (error, stdout, stderr) => {
         if (error) {
           logger.error('GitService: Git command failed', {
             args,
@@ -335,19 +352,30 @@ export class GitService implements vscode.Disposable {
     const repoRoot = this.repository.rootUri.fsPath;
     const filePaths = uris.map(u => u.fsPath);
 
+    // Track these as programmatic operations to prevent auto-assignment bounce-back
+    for (const filePath of filePaths) {
+      this.programmaticOperations.add(filePath);
+    }
+
+    // Convert to relative paths with forward slashes for Git consistency
+    const relativePaths = filePaths.map(p => {
+      const rel = path.relative(repoRoot, p);
+      return rel.replace(/\\/g, '/');
+    });
+
     logger.debug('GitService: Unstaging files via git reset', {
-      count: filePaths.length,
+      count: relativePaths.length,
       repoRoot,
-      files: filePaths,
+      files: relativePaths,
     });
 
     // Use git reset HEAD to unstage files
-    await this.runGitCommand(repoRoot, ['reset', 'HEAD', '--', ...filePaths]);
+    await this.runGitCommand(repoRoot, ['reset', 'HEAD', '--', ...relativePaths]);
 
     // Refresh repository state to pick up the changes
     await this.repository.status();
 
-    logger.info('GitService: Files unstaged successfully', { count: filePaths.length });
+    logger.info('GitService: Files unstaged successfully', { count: relativePaths.length });
   }
 
   /**

--- a/src/services/ideaSyncService.ts
+++ b/src/services/ideaSyncService.ts
@@ -1,0 +1,322 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { ChangeListManager } from './changeListManager';
+import { GitService } from './gitService';
+import { ConfigService } from './configService';
+import { Logger, logger } from '../utils/logger';
+import { normalizePathKey } from '../utils/helpers';
+
+/**
+ * Service for bi-directional synchronization of change lists with PhpStorm (.idea/workspace.xml)
+ */
+export class IdeaSyncService implements vscode.Disposable {
+  private disposables: vscode.Disposable[] = [];
+  private xmlFilePath: string | undefined;
+  private isWriting = false;
+  private fileWatcher: vscode.FileSystemWatcher | undefined;
+  private writeDebounceTimeout: NodeJS.Timeout | undefined;
+  private pollInterval: NodeJS.Timeout | undefined;
+  private lastMtime = 0;
+
+  constructor(
+    private readonly changeListManager: ChangeListManager,
+    private readonly gitService: GitService,
+    private readonly configService: ConfigService
+  ) {}
+
+  /**
+   * Initialize the sync service
+   */
+  async initialize(): Promise<void> {
+    if (!this.configService.getIdeaSyncEnabled()) {
+      logger.info('IdeaSyncService: Synchronization is disabled in settings');
+      return;
+    }
+
+    const workspaceRoot = this.gitService.getWorkspaceRoot();
+    if (!workspaceRoot) {
+      logger.debug('IdeaSyncService: No workspace root found. Synchronization disabled.');
+      return;
+    }
+
+    // Path to .idea/workspace.xml
+    const ideaPath = path.join(workspaceRoot.fsPath, '.idea');
+    this.xmlFilePath = path.join(ideaPath, 'workspace.xml');
+
+    try {
+      // Check if folder and file exist
+      await fs.access(this.xmlFilePath);
+      logger.info(`IdeaSyncService: Found PhpStorm config at ${this.xmlFilePath}`);
+    } catch {
+      logger.info('IdeaSyncService: .idea/workspace.xml not found. Synchronization disabled.');
+      this.xmlFilePath = undefined;
+      return;
+    }
+
+    // Initial import from PhpStorm to VS Code
+    await this.importFromIdea();
+
+    // Watch for external changes to .idea/workspace.xml
+    const watcherPattern = new vscode.RelativePattern(ideaPath, 'workspace.xml');
+    this.fileWatcher = vscode.workspace.createFileSystemWatcher(watcherPattern);
+    
+    this.disposables.push(
+      this.fileWatcher.onDidChange(async () => {
+        if (this.isWriting) {
+          logger.info('IdeaSyncService: Ignored file change event (internal write)');
+          return;
+        }
+        logger.info('IdeaSyncService: External change to workspace.xml detected via watcher, importing in 100ms...');
+        setTimeout(async () => {
+          await this.importFromIdea();
+        }, 100);
+      }),
+      this.fileWatcher.onDidCreate(async () => {
+        if (this.isWriting) return;
+        logger.info('IdeaSyncService: workspace.xml created via watcher, importing in 100ms...');
+        setTimeout(async () => {
+          await this.importFromIdea();
+        }, 100);
+      })
+    );
+
+    // Watch for local change list events in VS Code to write back to PhpStorm
+    this.disposables.push(
+      this.changeListManager.onDidChange((e) => {
+        // Skip writing on full refresh (which usually comes from an import or Git checkout)
+        if (e.type === 'refresh') {
+          return;
+        }
+        logger.debug(`IdeaSyncService: ChangeList state changed (${e.type}), scheduling write...`);
+        this.scheduleExportToIdea();
+      })
+    );
+
+    // Start polling fallback for UNC/WSL path compatibility
+    this.startPolling();
+
+    logger.info('IdeaSyncService: Successfully initialized and watching for changes');
+  }
+
+  /**
+   * Import change lists and file mappings from PhpStorm's workspace.xml into VS Code
+   */
+  async importFromIdea(): Promise<void> {
+    if (!this.xmlFilePath) return;
+
+    try {
+      // Update mtime to prevent polling loop
+      try {
+        const stats = await fs.stat(this.xmlFilePath);
+        this.lastMtime = stats.mtimeMs;
+      } catch (err) {
+        logger.warn('IdeaSyncService: Failed to stat workspace.xml during import', err);
+      }
+
+      const xmlContent = await fs.readFile(this.xmlFilePath, 'utf-8');
+      
+      // Extract ChangeListManager component
+      const componentMatch = xmlContent.match(/<component name="ChangeListManager">([\s\S]*?)<\/component>/);
+      if (!componentMatch) {
+        logger.debug('IdeaSyncService: ChangeListManager component not found in workspace.xml');
+        return;
+      }
+
+      const componentContent = componentMatch[1];
+      const parsedLists: { id: string; name: string; isDefault: boolean }[] = [];
+      const fileMapping: Record<string, string> = {};
+
+      // Match <list> tags (both self-closing and with children)
+      // Matches: <list id="..." name="..." ...> ... </list> OR <list id="..." name="..." ... />
+      const listRegex = /<list\b([\s\S]*?)(?:>([\s\S]*?)<\/list>|\/>)/g;
+      let listMatch;
+
+      while ((listMatch = listRegex.exec(componentContent)) !== null) {
+        const attributes = listMatch[1];
+        const innerContent = listMatch[2] || '';
+
+        const idMatch = attributes.match(/id="([^"]*)"/);
+        const nameMatch = attributes.match(/name="([^"]*)"/);
+        const defaultMatch = attributes.match(/default="([^"]*)"/);
+
+        if (!idMatch || !nameMatch) continue;
+
+        const id = idMatch[1];
+        const name = nameMatch[1];
+        const isDefault = defaultMatch ? defaultMatch[1] === 'true' : false;
+
+        parsedLists.push({ id, name, isDefault });
+
+        // Parse <change> tags in this list to populate fileMapping
+        const changeRegex = /<change\b([\s\S]*?)\/>/g;
+        let changeMatch;
+        const workspaceRoot = this.gitService.getWorkspaceRoot()?.fsPath;
+
+        while (workspaceRoot && (changeMatch = changeRegex.exec(innerContent)) !== null) {
+          const changeAttrs = changeMatch[1];
+          // Get beforePath or afterPath containing $PROJECT_DIR$/ or $PROJECT_DIR$/
+          const pathMatch = changeAttrs.match(/beforePath="\$PROJECT_DIR\$?\/(.*?)"/) || 
+                            changeAttrs.match(/afterPath="\$PROJECT_DIR\$?\/(.*?)"/);
+
+          if (pathMatch) {
+            const relativePath = pathMatch[1];
+            // Combine workspace root and relative path in a platform-independent way
+            const normalizedRoot = workspaceRoot.replace(/\\/g, '/');
+            const absolutePath = normalizedRoot.endsWith('/')
+              ? normalizedRoot + relativePath
+              : normalizedRoot + '/' + relativePath;
+            fileMapping[normalizePathKey(absolutePath)] = id;
+          }
+        }
+      }
+
+      if (parsedLists.length > 0) {
+        logger.info(`IdeaSyncService: Importing ${parsedLists.length} lists and ${Object.keys(fileMapping).length} mappings from PhpStorm`);
+        await this.changeListManager.importStateFromIdea(parsedLists, fileMapping);
+      }
+    } catch (error) {
+      logger.error('IdeaSyncService: Failed to import from workspace.xml', error);
+    }
+  }
+
+  /**
+   * Schedule an export to PhpStorm with debouncing
+   */
+  private scheduleExportToIdea(): void {
+    if (this.writeDebounceTimeout) {
+      clearTimeout(this.writeDebounceTimeout);
+    }
+
+    const interval = this.configService.getIdeaSyncInterval();
+    this.writeDebounceTimeout = setTimeout(async () => {
+      await this.exportToIdea();
+    }, interval);
+  }
+
+  /**
+   * Export the current VS Code change lists and mappings back to .idea/workspace.xml
+   */
+  async exportToIdea(): Promise<void> {
+    if (!this.xmlFilePath) return;
+
+    this.isWriting = true;
+    logger.debug('IdeaSyncService: Starting export to workspace.xml...');
+
+    try {
+      const xmlContent = await fs.readFile(this.xmlFilePath, 'utf-8');
+
+      // Generate the new ChangeListManager XML block
+      const newBlock = await this.generateXmlBlock();
+
+      const startTag = '<component name="ChangeListManager">';
+      const endTag = '</component>';
+      const startIndex = xmlContent.indexOf(startTag);
+      const endIndex = xmlContent.indexOf(endTag, startIndex);
+
+      if (startIndex !== -1 && endIndex !== -1) {
+        const updatedXml = 
+          xmlContent.substring(0, startIndex) + 
+          newBlock + 
+          xmlContent.substring(endIndex + endTag.length);
+
+        await fs.writeFile(this.xmlFilePath, updatedXml, 'utf-8');
+
+        // Update mtime to prevent polling loop
+        try {
+          const stats = await fs.stat(this.xmlFilePath);
+          this.lastMtime = stats.mtimeMs;
+        } catch (err) {
+          logger.warn('IdeaSyncService: Failed to stat workspace.xml during export', err);
+        }
+
+        logger.info('IdeaSyncService: Exported change lists successfully to .idea/workspace.xml');
+      } else {
+        logger.warn('IdeaSyncService: Could not locate ChangeListManager component in workspace.xml');
+      }
+    } catch (error) {
+      logger.error('IdeaSyncService: Failed to export to workspace.xml', error);
+    } finally {
+      // Release write lock after a brief timeout to allow OS / VS Code events to settle
+      setTimeout(() => {
+        this.isWriting = false;
+      }, 500);
+    }
+  }
+
+  /**
+   * Generate the XML string for the ChangeListManager component
+   */
+  private async generateXmlBlock(): Promise<string> {
+    const lists = this.changeListManager.getLists().filter(l => !l.isReadOnly);
+    const xmlLines: string[] = [];
+
+    xmlLines.push('  <component name="ChangeListManager">');
+
+    for (const list of lists) {
+      const defaultAttr = list.isDefault ? ' default="true"' : '';
+      const files = await this.changeListManager.getFilesForList(list.id);
+
+      if (files.length === 0) {
+        xmlLines.push(`    <list${defaultAttr} id="${list.id}" name="${list.name}" comment="" />`);
+      } else {
+        xmlLines.push(`    <list${defaultAttr} id="${list.id}" name="${list.name}" comment="">`);
+        for (const file of files) {
+          // JetBrains uses forward slashes in relative paths
+          const relPath = file.relativePath.replace(/\\/g, '/');
+          xmlLines.push(`      <change beforePath="$PROJECT_DIR$/${relPath}" beforeDir="false" afterPath="$PROJECT_DIR$/${relPath}" afterDir="false" />`);
+        }
+        xmlLines.push('    </list>');
+      }
+    }
+
+    // Preserve standard PhpStorm configuration options inside component
+    xmlLines.push('    <option name="SHOW_DIALOG" value="false" />');
+    xmlLines.push('    <option name="HIGHLIGHT_CONFLICTS" value="true" />');
+    xmlLines.push('    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />');
+    xmlLines.push('    <option name="LAST_RESOLUTION" value="IGNORE" />');
+    xmlLines.push('  </component>');
+
+    return xmlLines.join('\n');
+  }
+
+  dispose(): void {
+    if (this.writeDebounceTimeout) {
+      clearTimeout(this.writeDebounceTimeout);
+    }
+    if (this.pollInterval) {
+      clearInterval(this.pollInterval);
+    }
+    if (this.fileWatcher) {
+      this.fileWatcher.dispose();
+    }
+    this.disposables.forEach(d => d.dispose());
+  }
+
+  /**
+   * Start polling fallback for UNC/WSL path compatibility
+   */
+  private startPolling(): void {
+    if (!this.xmlFilePath) return;
+
+    const interval = 2500; // Poll every 2.5 seconds
+    this.pollInterval = setInterval(async () => {
+      if (this.isWriting) return;
+
+      try {
+        const stats = await fs.stat(this.xmlFilePath!);
+        const mtime = stats.mtimeMs;
+        
+        if (this.lastMtime === 0) {
+          this.lastMtime = mtime;
+        } else if (mtime > this.lastMtime) {
+          this.lastMtime = mtime;
+          logger.info(`IdeaSyncService: Polling detected external change to workspace.xml (mtime=${mtime}), importing...`);
+          await this.importFromIdea();
+        }
+      } catch (error) {
+        logger.warn('IdeaSyncService: Failed to poll workspace.xml stats', error);
+      }
+    }, interval);
+  }
+}

--- a/src/services/ideaSyncService.ts
+++ b/src/services/ideaSyncService.ts
@@ -18,6 +18,7 @@ export class IdeaSyncService implements vscode.Disposable {
   private writeDebounceTimeout: NodeJS.Timeout | undefined;
   private pollInterval: NodeJS.Timeout | undefined;
   private lastMtime = 0;
+  private readTimeout: NodeJS.Timeout | undefined;
 
   constructor(
     private readonly changeListManager: ChangeListManager,
@@ -67,15 +68,21 @@ export class IdeaSyncService implements vscode.Disposable {
           logger.info('IdeaSyncService: Ignored file change event (internal write)');
           return;
         }
-        logger.info('IdeaSyncService: External change to workspace.xml detected via watcher, importing in 100ms...');
-        setTimeout(async () => {
+        logger.info('IdeaSyncService: External change to workspace.xml detected via watcher, scheduling import...');
+        if (this.readTimeout) {
+          clearTimeout(this.readTimeout);
+        }
+        this.readTimeout = setTimeout(async () => {
           await this.importFromIdea();
         }, 100);
       }),
       this.fileWatcher.onDidCreate(async () => {
         if (this.isWriting) return;
-        logger.info('IdeaSyncService: workspace.xml created via watcher, importing in 100ms...');
-        setTimeout(async () => {
+        logger.info('IdeaSyncService: workspace.xml created via watcher, scheduling import...');
+        if (this.readTimeout) {
+          clearTimeout(this.readTimeout);
+        }
+        this.readTimeout = setTimeout(async () => {
           await this.importFromIdea();
         }, 100);
       })
@@ -142,8 +149,18 @@ export class IdeaSyncService implements vscode.Disposable {
 
         if (!idMatch || !nameMatch) continue;
 
-        const id = idMatch[1];
-        const name = nameMatch[1];
+        const id = idMatch[1]
+          .replace(/&amp;/g, '&')
+          .replace(/&lt;/g, '<')
+          .replace(/&gt;/g, '>')
+          .replace(/&quot;/g, '"')
+          .replace(/&apos;/g, "'");
+        const name = nameMatch[1]
+          .replace(/&amp;/g, '&')
+          .replace(/&lt;/g, '<')
+          .replace(/&gt;/g, '>')
+          .replace(/&quot;/g, '"')
+          .replace(/&apos;/g, "'");
         const isDefault = defaultMatch ? defaultMatch[1] === 'true' : false;
 
         parsedLists.push({ id, name, isDefault });
@@ -160,12 +177,13 @@ export class IdeaSyncService implements vscode.Disposable {
                             changeAttrs.match(/afterPath="\$PROJECT_DIR\$?\/(.*?)"/);
 
           if (pathMatch) {
-            const relativePath = pathMatch[1];
-            // Combine workspace root and relative path in a platform-independent way
-            const normalizedRoot = workspaceRoot.replace(/\\/g, '/');
-            const absolutePath = normalizedRoot.endsWith('/')
-              ? normalizedRoot + relativePath
-              : normalizedRoot + '/' + relativePath;
+            const relativePath = pathMatch[1]
+              .replace(/&amp;/g, '&')
+              .replace(/&lt;/g, '<')
+              .replace(/&gt;/g, '>')
+              .replace(/&quot;/g, '"')
+              .replace(/&apos;/g, "'");
+            const absolutePath = path.join(workspaceRoot, relativePath);
             fileMapping[normalizePathKey(absolutePath)] = id;
           }
         }
@@ -251,19 +269,32 @@ export class IdeaSyncService implements vscode.Disposable {
     const lists = this.changeListManager.getLists().filter(l => !l.isReadOnly);
     const xmlLines: string[] = [];
 
+    const escapeXml = (unsafe: string) => unsafe.replace(/[<>&'"]/g, (c) => {
+      switch (c) {
+        case '<': return '&lt;';
+        case '>': return '&gt;';
+        case '&': return '&amp;';
+        case '\'': return '&apos;';
+        case '"': return '&quot;';
+        default: return c;
+      }
+    });
+
     xmlLines.push('  <component name="ChangeListManager">');
 
     for (const list of lists) {
       const defaultAttr = list.isDefault ? ' default="true"' : '';
       const files = await this.changeListManager.getFilesForList(list.id);
+      const escapedId = escapeXml(list.id);
+      const escapedName = escapeXml(list.name);
 
       if (files.length === 0) {
-        xmlLines.push(`    <list${defaultAttr} id="${list.id}" name="${list.name}" comment="" />`);
+        xmlLines.push(`    <list${defaultAttr} id="${escapedId}" name="${escapedName}" comment="" />`);
       } else {
-        xmlLines.push(`    <list${defaultAttr} id="${list.id}" name="${list.name}" comment="">`);
+        xmlLines.push(`    <list${defaultAttr} id="${escapedId}" name="${escapedName}" comment="">`);
         for (const file of files) {
           // JetBrains uses forward slashes in relative paths
-          const relPath = file.relativePath.replace(/\\/g, '/');
+          const relPath = escapeXml(file.relativePath.replace(/\\/g, '/'));
           xmlLines.push(`      <change beforePath="$PROJECT_DIR$/${relPath}" beforeDir="false" afterPath="$PROJECT_DIR$/${relPath}" afterDir="false" />`);
         }
         xmlLines.push('    </list>');
@@ -281,6 +312,9 @@ export class IdeaSyncService implements vscode.Disposable {
   }
 
   dispose(): void {
+    if (this.readTimeout) {
+      clearTimeout(this.readTimeout);
+    }
     if (this.writeDebounceTimeout) {
       clearTimeout(this.writeDebounceTimeout);
     }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -36,6 +36,8 @@ export const CONFIG = {
   INTERCEPT_COMMIT: 'commitGuard.interceptCommit',
   AUTO_ASSIGN_STAGED: 'autoAssignStagedFiles',
   DEBUG_LOGGING: 'debug.enableLogging',
+  IDEA_SYNC_ENABLED: 'ideaSync.enabled',
+  IDEA_SYNC_INTERVAL: 'ideaSync.interval',
 } as const;
 
 /** Storage keys */

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { v4 as uuidv4 } from 'uuid';
+import { UNVERSIONED_LIST_ID } from './constants';
 
 /**
  * Generate a new UUID v4
@@ -22,7 +23,10 @@ export function getRelativePath(uri: vscode.Uri, workspaceRoot: vscode.Uri): str
   const rootPath = workspaceRoot.fsPath;
   const filePath = uri.fsPath;
 
-  if (filePath.startsWith(rootPath)) {
+  const normalizedRoot = rootPath.replace(/\\/g, '/').toLowerCase();
+  const normalizedFile = filePath.replace(/\\/g, '/').toLowerCase();
+
+  if (normalizedFile.startsWith(normalizedRoot)) {
     let relative = filePath.substring(rootPath.length);
     // Remove leading separator
     if (relative.startsWith('/') || relative.startsWith('\\')) {
@@ -39,6 +43,13 @@ export function getRelativePath(uri: vscode.Uri, workspaceRoot: vscode.Uri): str
  */
 export function normalizePath(path: string): string {
   return path.replace(/\\/g, '/');
+}
+
+/**
+ * Normalize path for use as a map key (lowercase, forward slashes)
+ */
+export function normalizePathKey(filePath: string): string {
+  return filePath.replace(/\\/g, '/').toLowerCase();
 }
 
 /**
@@ -111,10 +122,17 @@ export function groupBy<T, K extends string | number>(
 /**
  * Sort change lists with Default first, then active, then by name
  */
-export function sortChangeLists<T extends { isDefault: boolean; isActive: boolean; name: string }>(
+export function sortChangeLists<T extends { id?: string; isDefault: boolean; isActive: boolean; name: string }>(
   lists: T[]
 ): T[] {
   return [...lists].sort((a, b) => {
+    // Unversioned Files list always at the very end
+    const aIsUnversioned = a.id === UNVERSIONED_LIST_ID;
+    const bIsUnversioned = b.id === UNVERSIONED_LIST_ID;
+    if (aIsUnversioned !== bIsUnversioned) {
+      return aIsUnversioned ? 1 : -1;
+    }
+
     // Default list always first
     if (a.isDefault !== b.isDefault) {
       return a.isDefault ? -1 : 1;


### PR DESCRIPTION
- Add bi-directional change list sync with JetBrains/PhpStorm (using file watcher with periodic polling fallback for WSL/UNC paths)
- Fix Git commit tracking to properly remove committed files and prevent files from "bouncing" when moved back to Default list
- Fix path casing and slashes normalization for seamless compatibility in Windows/WSL environments
- Fix initialization race condition where imported change list mappings were wiped prematurely
- Add support for JetBrains $PROJECT_DIR$ macro in workspace.xml paths
- Add active change list indicator to the Status Bar with a quick switch menu
- Force virtual "Unversioned Files" list to always be sorted at the end of the view
- Sync package-lock.json to align with the AGPL-3.0-only license